### PR TITLE
Adding an agenda item for 2017-03-02 wrt cookbook quality metric 

### DIFF
--- a/2017-03-02-agenda.md
+++ b/2017-03-02-agenda.md
@@ -14,6 +14,7 @@ Secretary:  Nathen Harvey (nathenharvey)
   * Community update, speaker Nathen Harvey (nathenharvey): 5 minutes
   * Chef company update, speaker Adam Jacob (holoway): 5 minutes
   * Software update, speaker - various people: 5 minutes
+  * [Mechanism for announcing cookbook quality metrics rule changes](https://github.com/chef-cookbooks/cookbook-quality-metrics/issues/13), Jennifer Davis (iennae): 5 minutes
 * Review action items from last meeting (nathenharvey): 5 minutes
   * Discourse post about updating all Chef-manage cookbooks to require Chef 12.5 - Cookbook Engineering Team (@tas50, @sigje, @cheeseplus)
 * Review PRs:  35 minutes


### PR DESCRIPTION
Adding an agenda item for 2017-03-02 with regards to cookbook quality metric notifications, and clarifying README for agenda suggestions.

Signed-off-by: Jennifer Davis <iennae@gmail.com>